### PR TITLE
Dereference hash reference for using 'keys'

### DIFF
--- a/lib/DBIx/Fast.pm
+++ b/lib/DBIx/Fast.pm
@@ -157,7 +157,7 @@ sub update {
 
     my $sql = "UPDATE $table SET ";
 
-    for ( keys $skeel->{sen} ) {
+    for ( keys %{$skeel->{sen}} ) {
 	push @p,$skeel->{sen}->{$_};
 	$sql .= $_.' = ? ,';
     }
@@ -165,7 +165,7 @@ sub update {
     $sql =~ s/,$//;
     $sql .= 'WHERE ';
 
-    for my $K ( keys $skeel->{where} ) {
+    for my $K ( keys %{$skeel->{where}} ) {
 	push @p,$skeel->{where}->{$K};
 	$sql .= $K.' = ? ,';
     }
@@ -187,7 +187,7 @@ sub insert {
 
     my $sql= "INSERT INTO $table ( ";
 
-    for ( keys $skeel ) {
+    for ( keys %{$skeel} ) {
        push @p,$skeel->{$_};
        $sql .= $_.',';
     }
@@ -209,7 +209,7 @@ sub delete {
 
     my $sql = "DELETE FROM $table WHERE ";
 
-    for ( keys $skeel ) {
+    for ( keys %{$skeel} ) {
 	push @p,$skeel->{$_};
 	$sql .= $_.' = ? ,';
     }
@@ -246,7 +246,7 @@ sub make_sen {
     my @p;
 
     ## Ha de encontrar resultados por el orden de entrada parsear debidamente
-    for ( keys $skeel ) {
+    for ( keys %{$skeel} ) {
 	my $arg = ':'.$_;
 	push @p,$skeel->{$_};
 	$sql =~ s/$arg/\?/;


### PR DESCRIPTION
'keys' for reference is experimental feature.

I got following error when testing.

```
% prove -bv t/00-load.t
t/00-load.t .. 
not ok 1 - use DBIx::Fast;
Bailout called.  Further testing stopped:  
Bail out!

#   Failed test 'use DBIx::Fast;'
#   at t/00-load.t line 10.
#     Tried to use 'DBIx::Fast'.
#     Error:  keys on reference is experimental at /home/syohei/.cpanm/work/1426554600.11401/DBIx-Fast-0.02/blib/lib/DBIx/Fast.pm line 160.
# Compilation failed in require at t/00-load.t line 10.
# BEGIN failed--compilation aborted at t/00-load.t line 10.
Use of uninitialized value $DBIx::Fast::VERSION in concatenation (.) or string at t/00-load.t line 13.
# Looks like you failed 1 test of 1.
# Looks like your test exited with 255 just after 1.
FAILED--Further testing stopped
```
